### PR TITLE
Upgrade NHS.UK Frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@11ty/eleventy": "^2.0.1",
         "@nhsbsa/cookie-consent-component": "^0.0.6",
         "@x-govuk/govuk-eleventy-plugin": "^6.2.1",
-        "nhsuk-frontend": "^8.1.1"
+        "nhsuk-frontend": "^8.2.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -4003,9 +4003,9 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.1.1.tgz",
-      "integrity": "sha512-w+2ovXA8kQgR8YImqufx+cgqkmDjFUcW+VhHhgfBWBRjSPbAghUjlpIbkh6L7KCX0NI4xafOtSRV0+hL7viG6g=="
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.2.0.tgz",
+      "integrity": "sha512-qVMhgQqz0UD9D/sXqvllinge2WeGBwyBxdJAfcNxEvWl4oZ6FWCZbMFE9YCTqDjpfy9k2K251x8QJm1MssSA6Q=="
     },
     "node_modules/nodemon": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@11ty/eleventy": "^2.0.1",
     "@x-govuk/govuk-eleventy-plugin": "^6.2.1",
     "@nhsbsa/cookie-consent-component": "^0.0.6",
-    "nhsuk-frontend": "^8.1.1"
+    "nhsuk-frontend": "^8.2.0"
   },
   "private": true
 }


### PR DESCRIPTION
This upgrades NHS.UK Frontend from 8.1.1 to [8.2.0](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v8.2.0).

The only change for us is this fix to the spacing in our nested bulleted list:

| Before | After |
| ------ | ----- |
| <img width="751" alt="Screenshot showing bulleted list with uneven spacing" src="https://github.com/NHSDigital/record-a-vaccination-guidance/assets/30665/d2463598-7479-40e0-a729-83114bc006df"> | <img width="771" alt="Screenshot showing bulleted list with even spacing" src="https://github.com/NHSDigital/record-a-vaccination-guidance/assets/30665/abf975d8-9331-4c89-9aab-5b9dc16b1d5f"> |
