### PR TITLE
Update to NHSUK Frontend version 9

### DIFF
--- a/app/layouts/_base.njk
+++ b/app/layouts/_base.njk
@@ -33,6 +33,7 @@
 
   {% block main %}
     <div class="nhsuk-width-container ">
+      {% block beforeContent %}{% endblock %}
       <main class="nhsuk-main-wrapper " id="maincontent" role="main">
 
         {% block content %}

--- a/app/layouts/page.njk
+++ b/app/layouts/page.njk
@@ -2,7 +2,7 @@
 {% from 'breadcrumb/macro.njk' import breadcrumb %}
 {% from 'pagination/macro.njk' import pagination %}
 
-{% block main %}
+{% block beforeContent %}
   {{ breadcrumb({
     items: [
       {
@@ -13,22 +13,21 @@
     href: (parent.url | url) if parent,
     text: parent.title if parent
   }) }}
-  <div class="nhsuk-width-container ">
-    <main class="nhsuk-main-wrapper " id="maincontent" role="main">
-      <div class="nhsuk-grid-row">
-        <div class="nhsuk-grid-column-two-thirds">
-          <h1>{{ title }} </h1>
-          {{ content | safe }}
+{% endblock %}
 
-          {{ pagination({
-            "previousUrl": (previous.url | url) if previous,
-            "previousPage": previous.title if previous,
-            "nextUrl": (next.url | url) if next,
-            "nextPage": next.title if next
-          }) }}
+{% block content %}
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <h1 class="nhsuk-heading-xl">{{ title }} </h1>
+      {{ content | safe }}
 
-        </div>
-      </div>
-    </main>
+      {{ pagination({
+        "previousUrl": (previous.url | url) if previous,
+        "previousPage": previous.title if previous,
+        "nextUrl": (next.url | url) if next,
+        "nextPage": next.title if next
+      }) }}
+
+    </div>
   </div>
 {% endblock %}

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -8,6 +8,7 @@ module.exports = function(eleventyConfig) {
   let nunjucksEnvironment = new Nunjucks.Environment(
 		new Nunjucks.FileSystemLoader([
       './node_modules/nhsuk-frontend/packages/components',
+      './node_modules/nhsuk-frontend/packages/macros',
       './node_modules/govuk-frontend/dist',
       'app/layouts',
       'app/_includes'

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@11ty/eleventy": "^2.0.1",
         "@nhsbsa/cookie-consent-component": "^0.0.6",
         "@x-govuk/govuk-eleventy-plugin": "^6.2.1",
-        "nhsuk-frontend": "^8.2.0"
+        "nhsuk-frontend": "^9.0.1"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -3967,9 +3967,12 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-8.2.0.tgz",
-      "integrity": "sha512-qVMhgQqz0UD9D/sXqvllinge2WeGBwyBxdJAfcNxEvWl4oZ6FWCZbMFE9YCTqDjpfy9k2K251x8QJm1MssSA6Q=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.0.1.tgz",
+      "integrity": "sha512-pLuE7qPbuFaqyZzx874nLKrHLrquVW5z3/UsmwwP19zRWj9pW5qK519mDfLXnugAq1M5fQxjz5OvHofj0XAPdg==",
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/nodemon": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@11ty/eleventy": "^2.0.1",
     "@x-govuk/govuk-eleventy-plugin": "^6.2.1",
     "@nhsbsa/cookie-consent-component": "^0.0.6",
-    "nhsuk-frontend": "^8.2.0"
+    "nhsuk-frontend": "^9.0.1"
   },
   "private": true
 }


### PR DESCRIPTION
Updates to version 9.0.1 of NHS.UK Frontend.

This improves the default spacing between breadcrumbs and back links and h1s, as well as tweaking some of the heading font sizes.

The page template has to be updated slightly, as breadcrumbs are now expected to be contained in the `beforeContent` block within the `<div class="nhsuk-width-container">` container but before the `<main>` element.