### PR TITLE
Update onboarding-organisations.md

### DIFF
--- a/app/onboarding-organisations.md
+++ b/app/onboarding-organisations.md
@@ -38,7 +38,9 @@ If an organisation has stopped using RAVS for any reason, you should deactivate 
 
 As soon as an organisation has been deactivated, users will stop being able to record vaccinations for that organisation. 
 
-For 90 days, users will still be able to edit records and create reports. After 90 days, the organisation will be closed and users will no longer have any access to RAVS for that organisation.
+For 90 days, users will still be able to edit records and create reports. 
+
+After 90 days, the organisation will be closed and users will no longer have any access to RAVS for that organisation.
 
 ### How to reactivate a deactivated organisation
 


### PR DESCRIPTION
Added info to the regional guidance about how to close an organisation and what happens in what order when you do this. Plus miscellaneous minor edits such as changing the word 'provider' to 'organisation', and 'lead user' to either 'user' or 'lead administrator'. 