### PR TITLE
Update What's new and Reports for R21

### DIFF
--- a/app/reporting.md
+++ b/app/reporting.md
@@ -17,7 +17,7 @@ To create a report, select the 'Reports' link in the header.
 
 You will then be asked to select what you want to report on, including the:
 
-* timeframe (up to a maximum of 31 days)
+* timeframe (up to a maximum of 90 days)
 * vaccines
 * sites
 

--- a/app/whats-new.md
+++ b/app/whats-new.md
@@ -6,6 +6,22 @@ analytics_key: whats-new
 eleventyExcludeFromCollections: true
 ---
 
+## 7 April 2026
+ 
+### Longer timeframe for reports 
+
+You can now create a report for up 90 days. 
+
+### COVID-19 vaccine products 
+
+We’ve updated the list of COVID-19 vaccine products for the spring 2026 campaign.
+
+### RSV vaccination eligibility 
+
+For RSV, we’ve replaced the eligibility option **Aged 75 to 80 years old** with **Based on age or in an at-risk group**. This is to allow for the expanded eligibility criteria for RSV vaccinations.
+
+<hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
+
 ## 26 March 2026
  
 ### Recording a vaccination starts with patient search

--- a/app/whats-new.md
+++ b/app/whats-new.md
@@ -16,10 +16,6 @@ You can now create a report for up 90 days.
 
 We’ve updated the list of COVID-19 vaccine products for the spring 2026 campaign.
 
-### RSV vaccination eligibility 
-
-For RSV, we’ve replaced the eligibility option **Aged 75 to 80 years old** with **Based on age or in an at-risk group**. This is to allow for the expanded eligibility criteria for RSV vaccinations.
-
 <hr class="nhsuk-section-break nhsuk-section-break--m nhsuk-section-break--visible">
 
 ## 26 March 2026


### PR DESCRIPTION
What's new updates for 7 April:

- 90-day reports
- new COVID-19 products
- new RSV eligibility

In Reports, maximum timeframe changed to 90 days.