### PR TITLE
Update guidance index and record pages

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -20,11 +20,13 @@ To access the service, go to [NHS Record a vaccination](https://www.ravs.england
 
 ## The vaccinations you can record in RAVS
 
-Depending on your setting, you can record all or some of these vaccinations in RAVS:
+Depending on your setting, you can record some or all of these vaccinations in RAVS:
 
 - COVID-19
 - Flu
 - Pertussis
 - RSV
+- MenB
 - Pneumococcal
-- MenB   
+
+Last updated: 17 April 2026

--- a/app/index.md
+++ b/app/index.md
@@ -27,6 +27,7 @@ Depending on your setting, you can record some or all of these vaccinations in R
 - Pertussis
 - RSV
 - MenB
+- MMR
 - Pneumococcal
 
 Last updated: 17 April 2026

--- a/app/index.md
+++ b/app/index.md
@@ -18,21 +18,13 @@ You can also:
 
 To access the service, go to [NHS Record a vaccination](https://www.ravs.england.nhs.uk).
 
-## Vaccination data
+## The vaccinations you can record in RAVS
 
+Depending on your setting, you can record all or some of these vaccinations in RAVS:
 
-| Vaccine          | Can be recorded in RAVS | Shown in RAVS vaccination history if recorded by a GP |
-|------------------|-----------------|---------------------------------|
-| COVID-19         | Yes             | Yes                             |
-| Flu              | Yes             | Yes                             |
-| MMR              | Yes             | No                              |
-| Pertussis        | Yes             | No                              |
-| Pneumococcal     | Yes             | No                              |
-| RSV              | Yes             | Yes                             |
-
-
-### Data sent to GPs
-
-All vaccinations recorded in RAVS will appear in the patient's GP record.
-
-When you record vaccinations in RAVS, do not send these records to GPs as this may create duplicate entries in the patient's GP record.
+- COVID-19
+- Flu
+- Pertussis
+- RSV
+- Pneumococcal
+- MenB   

--- a/app/record-vaccinations.md
+++ b/app/record-vaccinations.md
@@ -25,6 +25,20 @@ First, we ask for the patient’s NHS number, or their name and date of birth.
 
 We then look up the patient. If a match is found, you'll be shown the patient's details and vaccination history. 
 
+{% from "details/macro.njk" import details %}
+
+{% call details({
+  summaryText: "What is included in the vaccination history",
+  classes: "nhsuk-expander"
+}) %}
+  <p>Currently you can expect to see:</p>
+  <ul>
+    <li>all vaccinations recorded in RAVS, including flu, COVID-19, pertussis, RSV, MenB, MMR and pneumococcal </li>
+    <li>most flu, COVID-19 and RSV vaccinations recorded in other systems </li>
+    <li>some MMR, MenB and pneumococcal vaccinations recorded in other systems </li>
+  </ul>
+{% endcall %}
+
 If no match is found for the details you entered, you have the option to record a vaccination without an NHS number. 
 
 > [!NOTE]

--- a/app/record-vaccinations.md
+++ b/app/record-vaccinations.md
@@ -25,19 +25,22 @@ First, we ask for the patient’s NHS number, or their name and date of birth.
 
 We then look up the patient. If a match is found, you'll be shown the patient's details and vaccination history. 
 
-{% from "details/macro.njk" import details %}
+<details class="nhsuk-details nhsuk-expander">
+  <summary class="nhsuk-details__summary">
+    <span class="nhsuk-details__summary-text">
+      What is included in the vaccination history
+    </span>
+  </summary>
+  <div class="nhsuk-details__text">
+    <p>Currently you can expect to see:</p>
+    <ul>
+      <li>all vaccinations recorded in RAVS, including flu, COVID-19, pertussis, RSV, MenB, MMR and pneumococcal </li>
+      <li>most flu, COVID-19 and RSV vaccinations recorded in other systems </li>
+      <li>some MMR, MenB and pneumococcal vaccinations recorded in other systems </li>
+    </ul>
 
-{% call details({
-  summaryText: "What is included in the vaccination history",
-  classes: "nhsuk-expander"
-}) %}
-  <p>Currently you can expect to see:</p>
-  <ul>
-    <li>all vaccinations recorded in RAVS, including flu, COVID-19, pertussis, RSV, MenB, MMR and pneumococcal </li>
-    <li>most flu, COVID-19 and RSV vaccinations recorded in other systems </li>
-    <li>some MMR, MenB and pneumococcal vaccinations recorded in other systems </li>
-  </ul>
-{% endcall %}
+  </div>
+</details>
 
 If no match is found for the details you entered, you have the option to record a vaccination without an NHS number. 
 


### PR DESCRIPTION
On index page, removed table about vaccination data but kept a list of the vaccinations you can record in RAVS.

<img width="370" height="460" alt="image" src="https://github.com/user-attachments/assets/d9d9e98c-ee23-4c84-9eb2-ca30545213fa" />

<br>
On record page, added an expander component with details of the vaccinations you can expect to see in a patient's vaccination history on RAVS. 

<img width="310" height="344" alt="image" src="https://github.com/user-attachments/assets/269b2de7-c71c-4400-9edb-6539b02a4b3a" />
<br>
<img width="324" height="245" alt="image" src="https://github.com/user-attachments/assets/0f97301d-562a-4092-8413-b02dc090f703" />
