### PR TITLE
Update current for training video link

### DIFF
--- a/app/_includes/guide-contents.njk
+++ b/app/_includes/guide-contents.njk
@@ -40,7 +40,7 @@
     {
       href: "/training-video/",
       text: "Training video",
-      current: (page.url == "/managing-users/")
+      current: (page.url == "/training-video/")
     },
     {
       href: "/service-unavailable/",


### PR DESCRIPTION
Small bug in the nav where the `Training video` link had the wrong `current` applied to it.

<img width="572" height="675" alt="User guide for RAVS. The navigation has a bug which makes it unclear which page is current." src="https://github.com/user-attachments/assets/57949073-d877-49ca-9fba-19102325d142" />

This meant that when on the `Managing users` page, the nav made it look like both `Managing users` and `Training video` pages were selected.
