### PR TITLE
Closed a tag in cookie banner

### DIFF
--- a/app/_includes/cookie-banner.njk
+++ b/app/_includes/cookie-banner.njk
@@ -4,7 +4,7 @@
       <h2>Cookies on NHS Record a vaccination guidance</h2>
       <p>We’d also like to use analytics cookies. These collect feedback and send information about how our site is used to a service called Adobe Analytics. We use this information to improve our guidance.
 
-      <p>Let us know if this is OK. We’ll use a cookie to save your choice. You can <a id="nhsuk-cookie-banner__link" href="/cookie-preferences" data-policy-url="/cookie-preferences">read more about our cookies before you choose.
+      <p>Let us know if this is OK. We’ll use a cookie to save your choice. You can <a id="nhsuk-cookie-banner__link" href="/cookie-preferences" data-policy-url="/cookie-preferences">read more about our cookies</a> before you choose.
 
       <ul>
         <li><button class="nhsuk-button" id="nhsuk-cookie-banner__link_accept_analytics" href="#">Accept analytics cookies</button></li><li><button class='nhsuk-button' id="nhsuk-cookie-banner__link_accept" href="#">Reject analytics cookies</button></li>


### PR DESCRIPTION
### Background

Was using [WAVE](https://wave.webaim.org/extension/) to do some light accessibility testing.  

Wave was showing an error of  3 x links without text

<img width="1410" height="941" alt="Screenshot of WAVE extension on Chrome applied to RAVS guidance home page" src="https://github.com/user-attachments/assets/5c157954-e81e-4701-b465-a66fddd4362d" />

### Fix

Realised that there was an unclosed `<a>` tag in the cookie banner.

I've added that now, I've made an educated guess to decide that the link should wrap the phrase `read more about our cookies`. As per screenshot below...

<img width="1043" height="370" alt="Screenshot of RAVS guidance cookie banner containing a link and 2 buttons" src="https://github.com/user-attachments/assets/3ae2422a-a179-4b8c-8d2f-119011770e8a" />

